### PR TITLE
Create dict_autoupdate in Bug class

### DIFF
--- a/tests/data/clioutput/test_query2.txt
+++ b/tests/data/clioutput/test_query2.txt
@@ -27,6 +27,7 @@ ATTRIBUTE[cf_verified]: []
 ATTRIBUTE[classification]: Red Hat
 ATTRIBUTE[comments]: ['DICT SCRUBBED']
 ATTRIBUTE[depends_on]: [112233]
+ATTRIBUTE[dict_autoupdate]: False
 ATTRIBUTE[docs_contact]: 
 ATTRIBUTE[estimated_time]: 0.0
 ATTRIBUTE[external_bugs]: ['DICT SCRUBBED']

--- a/tests/data/mockreturn/test_getbug_dict_autoupdate.txt
+++ b/tests/data/mockreturn/test_getbug_dict_autoupdate.txt
@@ -1,0 +1,15 @@
+{'faults': [],
+ "bugs" : [{
+  'summary': 'Yet another problem',
+  'id': 1165434,
+  'status': 'NEW',
+  'resolution': '',
+  'assigned_to': 'user1@datacom.com.br',
+  'cc': ['user10@datacom.com.br',
+         'user11@datacom.com.br',
+         'user12@datacom.com.br'],
+  'flags': [{'name': 'flag1', 'status': '?'},
+            {'name': 'flag2', 'status': '?'},
+            {'name': 'flag3', 'status': '?'}]
+ }]
+}

--- a/tests/test_api_bug.py
+++ b/tests/test_api_bug.py
@@ -221,3 +221,201 @@ def test_bug_weburl():
     bug_id = 1165434
     bug = fakebz.getbug(bug_id)
     assert bug.weburl == f"https:///show_bug.cgi?id={bug_id}"
+
+
+def test_dict_autoupdate():
+    def _get_fake_bug(dict_autoupdate):
+        fakebz = tests.mockbackend.make_bz(rhbz=True,
+            bug_get_args=None,
+            bug_get_return="data/mockreturn/test_getbug_dict_autoupdate.txt",
+            bug_update_args=None,
+            bug_update_return={})
+        fakebz.bug_dict_autoupdate = dict_autoupdate
+        return fakebz.getbug(1165434)
+
+    ################################
+    # With dict_autoupdate ENABLED #
+    ################################
+
+    # test Bug.setstatus
+    bug = _get_fake_bug(dict_autoupdate=True)
+    assert bug.status == 'NEW'
+    assert bug.get_raw_data()['status'] == 'NEW'
+    bug.setstatus('IN-PROGRESS')
+    assert bug.status == 'IN-PROGRESS'
+    assert bug.get_raw_data()['status'] == 'IN-PROGRESS'
+
+    # test Bug.close
+    bug = _get_fake_bug(dict_autoupdate=True)
+    assert bug.status == 'NEW'
+    assert bug.resolution == ''
+    assert bug.get_raw_data()['status'] == 'NEW'
+    assert bug.get_raw_data()['resolution'] == ''
+    bug.close('FIXED')
+    assert bug.status == 'CLOSED'
+    assert bug.resolution == 'FIXED'
+    assert bug.get_raw_data()['status'] == 'CLOSED'
+    assert bug.get_raw_data()['resolution'] == 'FIXED'
+
+    # test Bug.setassignee
+    bug = _get_fake_bug(dict_autoupdate=True)
+    assert bug.assigned_to == 'user1@datacom.com.br'
+    assert bug.get_raw_data()['assigned_to'] == 'user1@datacom.com.br'
+    bug.setassignee('user2@datacom.com.br')
+    assert bug.assigned_to == 'user2@datacom.com.br'
+    assert bug.get_raw_data()['assigned_to'] == 'user2@datacom.com.br'
+
+    # test Bug.addcc
+    bug = _get_fake_bug(dict_autoupdate=True)
+    assert bug.cc == ['user10@datacom.com.br', 'user11@datacom.com.br',
+                      'user12@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user11@datacom.com.br',
+                                        'user12@datacom.com.br']
+    bug.addcc('user20@datacom.com.br')
+    assert bug.cc == ['user10@datacom.com.br', 'user11@datacom.com.br',
+                      'user12@datacom.com.br', 'user20@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user11@datacom.com.br',
+                                        'user12@datacom.com.br',
+                                        'user20@datacom.com.br']
+
+    # test Bug.deletecc
+    bug = _get_fake_bug(dict_autoupdate=True)
+    assert bug.cc == ['user10@datacom.com.br', 'user11@datacom.com.br',
+                      'user12@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user11@datacom.com.br',
+                                        'user12@datacom.com.br']
+    bug.deletecc('user11@datacom.com.br')
+    assert bug.cc == ['user10@datacom.com.br', 'user12@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user12@datacom.com.br']
+
+    # test Bug.updateflags
+    bug = _get_fake_bug(dict_autoupdate=True)
+    assert bug.flags == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '?'},
+        {'name': 'flag3', 'status': '?'}
+    ]
+    assert bug.get_raw_data()['flags'] == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '?'},
+        {'name': 'flag3', 'status': '?'}
+    ]
+    bug.updateflags({'flag1': '?', 'flag2': '+', 'flag3': '-',
+                     'flag4': '?'})
+    assert bug.flags == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '+'},
+        {'name': 'flag3', 'status': '-'},
+        {'name': 'flag4', 'status': '?'}
+    ]
+    assert bug.get_raw_data()['flags'] == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '+'},
+        {'name': 'flag3', 'status': '-'},
+        {'name': 'flag4', 'status': '?'}
+    ]
+
+    # test Bug.setsummary
+    bug = _get_fake_bug(dict_autoupdate=True)
+    assert bug.summary == 'Yet another problem'
+    assert bug.get_raw_data()['summary'] == 'Yet another problem'
+    bug.setsummary('A really weird problem')
+    assert bug.summary == 'A really weird problem'
+    assert bug.get_raw_data()['summary'] == 'A really weird problem'
+
+    #################################
+    # With dict_autoupdate DISABLED #
+    #################################
+
+    # test Bug.setstatus
+    bug = _get_fake_bug(dict_autoupdate=False)
+    assert bug.status == 'NEW'
+    assert bug.get_raw_data()['status'] == 'NEW'
+    bug.setstatus('IN-PROGRESS')
+    assert bug.status == 'NEW'
+    assert bug.get_raw_data()['status'] == 'NEW'
+
+    # test Bug.close
+    bug = _get_fake_bug(dict_autoupdate=False)
+    assert bug.status == 'NEW'
+    assert bug.resolution == ''
+    assert bug.get_raw_data()['status'] == 'NEW'
+    assert bug.get_raw_data()['resolution'] == ''
+    bug.close('FIXED')
+    assert bug.status == 'NEW'
+    assert bug.resolution == ''
+    assert bug.get_raw_data()['status'] == 'NEW'
+    assert bug.get_raw_data()['resolution'] == ''
+
+    # test Bug.setassignee
+    bug = _get_fake_bug(dict_autoupdate=False)
+    assert bug.assigned_to == 'user1@datacom.com.br'
+    assert bug.get_raw_data()['assigned_to'] == 'user1@datacom.com.br'
+    bug.setassignee('user2@datacom.com.br')
+    assert bug.assigned_to == 'user1@datacom.com.br'
+    assert bug.get_raw_data()['assigned_to'] == 'user1@datacom.com.br'
+
+    # test Bug.addcc
+    bug = _get_fake_bug(dict_autoupdate=False)
+    assert bug.cc == ['user10@datacom.com.br', 'user11@datacom.com.br',
+                      'user12@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user11@datacom.com.br',
+                                        'user12@datacom.com.br']
+    bug.addcc('user20@datacom.com.br')
+    assert bug.cc == ['user10@datacom.com.br', 'user11@datacom.com.br',
+                      'user12@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user11@datacom.com.br',
+                                        'user12@datacom.com.br']
+
+    # test Bug.deletecc
+    bug = _get_fake_bug(dict_autoupdate=False)
+    assert bug.cc == ['user10@datacom.com.br', 'user11@datacom.com.br',
+                      'user12@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user11@datacom.com.br',
+                                        'user12@datacom.com.br']
+    bug.deletecc('user11@datacom.com.br')
+    assert bug.cc == ['user10@datacom.com.br', 'user11@datacom.com.br',
+                      'user12@datacom.com.br']
+    assert bug.get_raw_data()['cc'] == ['user10@datacom.com.br',
+                                        'user11@datacom.com.br',
+                                        'user12@datacom.com.br']
+
+    # test Bug.updateflags
+    bug = _get_fake_bug(dict_autoupdate=False)
+    assert bug.flags == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '?'},
+        {'name': 'flag3', 'status': '?'}
+    ]
+    assert bug.get_raw_data()['flags'] == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '?'},
+        {'name': 'flag3', 'status': '?'}
+    ]
+    bug.updateflags({'flag1': '?', 'flag2': '+', 'flag3': '-',
+                     'flag4': '?'})
+    assert bug.flags == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '?'},
+        {'name': 'flag3', 'status': '?'}
+    ]
+    assert bug.get_raw_data()['flags'] == [
+        {'name': 'flag1', 'status': '?'},
+        {'name': 'flag2', 'status': '?'},
+        {'name': 'flag3', 'status': '?'}
+    ]
+
+    # test Bug.setsummary
+    bug = _get_fake_bug(dict_autoupdate=False)
+    assert bug.summary == 'Yet another problem'
+    assert bug.get_raw_data()['summary'] == 'Yet another problem'
+    bug.setsummary('A really weird problem')
+    assert bug.summary == 'Yet another problem'
+    assert bug.get_raw_data()['summary'] == 'Yet another problem'


### PR DESCRIPTION
dict_autoupdate is a parameter that can be passed in Bug's constructor that instructs Bug class to auto update local dictionary when a set/add/update method is called.

When this parameter is False, the Bug class will work as always: if you perform a set/add/update action then read the attribute related to the performed action, it will not show the new value, but the old one.

When dict_autoupdate is True, the Bug class will update internal dictionary using the new value passed in set/add/update method.

To do that some changes have to be done:
 - Create helper methods inside of Bug class
 - Modify set/add/update methods adding calls for updating dictionary
 - Add a new optional parameter to Bug's constructor
 - Modify Bugzilla class to add support to dict_autoupdate parameter
 - Update test_query2.txt to avoid tests to be broken by new parameter

Also done:
 - A new unit test for this feature
 - Pylint fixes